### PR TITLE
2016 08 fixes

### DIFF
--- a/src/game/server/swarm/asw_marine.cpp
+++ b/src/game/server/swarm/asw_marine.cpp
@@ -2338,6 +2338,9 @@ void CASW_Marine::ASWThinkEffects()
 			pExtra->ItemPostFrame();
 			gpGlobals->frametime = flSavedFrameTime;
 		}
+
+		// make sure we open doors even if we don't move
+		PhysicsTouchTriggers();
 	}
 
 	if ( gpGlobals->curtime > m_flNextBreadcrumbTime )

--- a/src/game/server/swarm/asw_parasite.cpp
+++ b/src/game/server/swarm/asw_parasite.cpp
@@ -678,6 +678,11 @@ bool CASW_Parasite::CheckInfestTarget( CBaseEntity *pOther )
 
 void CASW_Parasite::StartInfestation()
 {
+	if ( !IsAlive() )
+	{
+		return;
+	}
+
 	CASW_Marine* pMarine = CASW_Marine::AsMarine( m_hPrepareToInfest.Get() );
 	if ( pMarine )
 	{

--- a/src/game/server/swarm/asw_parasite.cpp
+++ b/src/game/server/swarm/asw_parasite.cpp
@@ -768,7 +768,8 @@ void CASW_Parasite::InfestMarine(CASW_Marine* pMarine)
 				ResetSequence(iInfestAttack);
 			}
 		}
-		
+
+		m_takedamage = DAMAGE_NO;
 		AddFlag( FL_NOTARGET );
 		SetThink( &CASW_Parasite::InfestThink );
 		SetTouch( NULL );

--- a/src/game/shared/swarm/asw_weapon_grenade_launcher.cpp
+++ b/src/game/shared/swarm/asw_weapon_grenade_launcher.cpp
@@ -72,11 +72,7 @@ ConVar asw_grenade_launcher_gravity( "asw_grenade_launcher_gravity", "2.4f", FCV
 #endif
 
 void CASW_Weapon_Grenade_Launcher::PrimaryAttack( void )
-{	
-	CASW_Player *pPlayer = GetCommander();
-	if ( !pPlayer )
-		return;
-
+{
 	// NOTE: this class is now a grenade launcher, do we want to rename it at some point?
 	CASW_Marine *pMarine = GetMarine();
 	if ( !pMarine || pMarine->GetWaterLevel() == 3 )
@@ -94,7 +90,8 @@ void CASW_Weapon_Grenade_Launcher::PrimaryAttack( void )
 	if (pm.fraction < 1.0f)
 		vecSrc = pm.endpos;
 
-	Vector vecDest = pPlayer->GetCrosshairTracePos();
+	CASW_Player *pPlayer = GetCommander();
+	Vector vecDest = (pPlayer && pMarine->IsInhabited()) ? pPlayer->GetCrosshairTracePos() : pMarine->GetEnemyLKP();
 	Vector newVel = UTIL_LaunchVector( vecSrc, vecDest, asw_grenade_launcher_gravity.GetFloat() ) * 28.0f;
 
 	const float &fGrenadeDamage = MarineSkills()->GetSkillBasedValueByMarine(pMarine, ASW_MARINE_SKILL_GRENADES, ASW_MARINE_SUBSKILL_GRENADE_CLUSTER_DMG);


### PR DESCRIPTION
- Fix bots shooting the grenade launcher at their commander's cursor instead of their target.
- Fix doors closing on bot marines that aren't moving.
- Fix parasites infesting marines that killed them using melee.
- Fix parasites being killable after they infest a marine (visual bug only, no gameplay change).
